### PR TITLE
Caching & Sanitizing inner element text

### DIFF
--- a/lib/eaal/cache/file.rb
+++ b/lib/eaal/cache/file.rb
@@ -59,6 +59,6 @@ class EAAL::Cache::FileCache
   def save(userid, apikey, scope, name, args, xml)
     filename = self.filename(userid, apikey,scope,name,args)
     FileUtils.mkdir_p(File.dirname(filename))
-    File.open(filename,'w') { |f| f.print xml }
+    File.open(filename,'wb') { |f| f.print xml }
   end
 end

--- a/lib/eaal/result.rb
+++ b/lib/eaal/result.rb
@@ -70,7 +70,7 @@ module EAAL
                         }
                         value = container
                     else
-                        value = element.inner_html
+                        value = element.inner_html.gsub(/\W+/, "") #Mainly to filter tags within description element in corporationsheet.
                     end
                     re = ResultElement.new(key, value)
                     if element.attributes.to_hash.length > 0


### PR DESCRIPTION
Caching was unable to write properly, possibly only a issue when using
ruby 1.9.2.

EAAL breaks when making a corporationsheet request that has a
description with elements within. I've added a regex to filter tags
before becoming a new ResultElement.

Two small fixes.
