### PR TITLE
Updated Version

### DIFF
--- a/lib/eaal.rb
+++ b/lib/eaal.rb
@@ -35,7 +35,7 @@ require 'eaal/result'
 require 'eaal/rowset'
 module EAAL
   mattr_reader :version_string
-  VERSION = "0.1.7" # fix for Hoe.spec 2.x
+  VERSION = "0.1.8" # fix for Hoe.spec 2.x
   @@version_string = "EAAL" +  VERSION # the version string, used as client name in http requests
 
   mattr_accessor :api_base, :additional_request_parameters, :cache


### PR DESCRIPTION
"gem install eaal" installs verions 0.1.7 but does not include the new API auth attributes keyed and vcode. I think the higher version number is necessary for an ruby gem update. If something is missing for an gem update complete it. ;)
