### PR TITLE
ResultContainer#to_hash

### DIFF
--- a/lib/eaal.rb
+++ b/lib/eaal.rb
@@ -35,7 +35,7 @@ require 'eaal/result'
 require 'eaal/rowset'
 module EAAL
   mattr_reader :version_string
-  VERSION = "0.1.8" # fix for Hoe.spec 2.x
+  VERSION = "0.1.9" # fix for Hoe.spec 2.x
   @@version_string = "EAAL" +  VERSION # the version string, used as client name in http requests
 
   mattr_accessor :api_base, :additional_request_parameters, :cache

--- a/lib/eaal/result.rb
+++ b/lib/eaal/result.rb
@@ -27,6 +27,11 @@ module EAAL
             def method_missing(method, *args)
                 self.container[method.id2name]
             end
+
+            def to_hash
+                hash = {}
+                return hash.merge!(self.container)
+            end
         end
 
         # result element
@@ -48,7 +53,6 @@ module EAAL
                 else
                     self.value.send(method, *args)
                 end
-
             end
 
             # parses an xml element to create either the ResultElement, ResultContainer or Rowset


### PR DESCRIPTION
- return copy of attributes as hash

I don't  know if there is already a way to access these attributes directly.
If there is one, please tell me and dismiss this pull request.
