### PR TITLE
Refined ResultContainer#to_hash 

### DIFF
--- a/lib/eaal.rb
+++ b/lib/eaal.rb
@@ -35,7 +35,7 @@ require 'eaal/result'
 require 'eaal/rowset'
 module EAAL
   mattr_reader :version_string
-  VERSION = "0.1.9" # fix for Hoe.spec 2.x
+  VERSION = "0.1.10" # fix for Hoe.spec 2.x
   @@version_string = "EAAL" +  VERSION # the version string, used as client name in http requests
 
   mattr_accessor :api_base, :additional_request_parameters, :cache

--- a/lib/eaal/result.rb
+++ b/lib/eaal/result.rb
@@ -29,8 +29,12 @@ module EAAL
             end
 
             def to_hash
-                hash = {}
-                return hash.merge!(self.container)
+                if self.container == {}
+                    vars = self.instance_variables
+                    vars.delete_at(0) # delete container var name
+                    vars.each {|v| self.container[v.to_s.gsub("@","")] = self.instance_variable_get v }
+                end
+                return self.container.dup
             end
         end
 


### PR DESCRIPTION
In some cases :container was empty. If empty it loads the instance
variables into it.

Thanks for merging! :)
