### PR TITLE
Added support for attributes on containers (Issue #12)

### DIFF
--- a/lib/eaal/result.rb
+++ b/lib/eaal/result.rb
@@ -14,10 +14,11 @@ module EAAL
 
         # Result Container class, ...
         class ResultContainer
-            attr_accessor :container
+            attr_accessor :container, :attribs
 
             def initialize
                 self.container = {}
+                self.attribs = {}
             end
 
             def add_element(key, val)
@@ -25,7 +26,11 @@ module EAAL
             end
 
             def method_missing(method, *args)
-                self.container[method.id2name]
+                if self.attribs.has_key?(method.id2name)
+                    self.attribs[method.id2name]
+                else
+                    self.container[method.id2name]
+                end
             end
 
             def to_hash
@@ -84,6 +89,9 @@ module EAAL
                     re = ResultElement.new(key, value)
                     if element.attributes.to_hash.length > 0
                         re.attribs.merge!(element.attributes.to_hash)
+                        if re.value.respond_to?(:attribs)
+                            re.value.attribs.merge!(element.attributes.to_hash)
+                        end
                     end
                 end
                 re
@@ -105,6 +113,7 @@ module EAAL
             elements = (xml/"eveapi/result").first.containers
             elements.each {|element|
                 el = EAAL::Result::ResultElement.parse_element(prefix, element)
+
                 members << el.name
                 if el.kind_of? EAAL::Rowset::RowsetBase
                     values.merge!({el.name => el})

--- a/test/fixtures/test/test/account/APIKeyInfo/Request_.xml
+++ b/test/fixtures/test/test/account/APIKeyInfo/Request_.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<eveapi version="2">
+  <currentTime>2008-12-08 15:02:25</currentTime>
+  <result>
+    <key accessMask="59760264" type="Character" expires="2011-09-11 00:00:00">
+      <rowset name="characters" key="characterID" columns="characterID,characterName,corporationID,corporationName">
+        <row characterID="12345" characterName="Tester" corporationID="45678" corporationName="Test Corp" />
+      </rowset>
+    </key>
+  </result>
+  <cachedUntil>2020-12-08 16:02:25</cachedUntil>
+</eveapi>

--- a/test/test_eaal.rb
+++ b/test/test_eaal.rb
@@ -57,6 +57,18 @@ class TestEaal < Test::Unit::TestCase
    assert_kind_of EAAL::Rowset::RowsetBase, @api.AllianceList.alliances.first.memberCorporations
   end
 
+  # test for ApiKeyInfo.xml
+  def test_api_key
+    @api.scope = "account"
+    assert_equal @api.APIKeyInfo.key.characters.length, 1
+    assert_equal @api.APIKeyInfo.key.characters[0].characterID, '12345'
+    assert_equal @api.APIKeyInfo.key.characters[0].characterName, 'Tester'
+    assert_equal @api.APIKeyInfo.key.characters[0].corporationID, '45678'
+    assert_equal @api.APIKeyInfo.key.accessMask, '59760264'
+    assert_equal @api.APIKeyInfo.key.type, 'Character'
+    assert_equal @api.APIKeyInfo.key.expires, '2011-09-11 00:00:00'
+  end
+
   # test for Standings.xml
   def test_standings
     @api.scope = "account"


### PR DESCRIPTION
This seems to only be needed for the APIKeyInfo API endpoint, to access the accessMask, type and expires attributes of the key.  It should fix the problem described in Issue #12.
