### PR TITLE
Use Time.zone.parse to avoid using local time

### DIFF
--- a/lib/eaal/cache/file.rb
+++ b/lib/eaal/cache/file.rb
@@ -49,7 +49,7 @@ class EAAL::Cache::FileCache
   # validate cached datas cachedUntil
   def validate_cache(xml, name)
     doc = Hpricot.XML(xml)
-    cached_until = Time.parse((doc/"/eveapi/cachedUntil").inner_html)
+    cached_until = Time.zone.parse((doc/"/eveapi/cachedUntil").inner_html)
     if name == "WalletJournal"
       result = Time.at(cached_until.to_i + 3600) > Time.now.utc
     else


### PR DESCRIPTION
I noticed that the cache uses Time.parse to parse the cached_until value. Time.parse seems to use the local time zone, resulting in the UTC time being incorrectly interpreted. Using Time.zone.parse fixed this issue for me.
