### PR TITLE
Add 'status' attribute to HTTPError exception

### DIFF
--- a/lib/eaal/api.rb
+++ b/lib/eaal/api.rb
@@ -60,7 +60,7 @@ class EAAL::API
       when 404
         raise EAAL::Exception::APINotFoundError.new("The requested API (#{scope} / #{name}) could not be found.")
       else
-        raise EAAL::Exception::HTTPError.new("An HTTP Error occured, body: " + response.body)
+        raise EAAL::Exception::HTTPError.new(response.status), "An HTTP Error occurred, body: #{response.body}"
       end
 
       EAAL.cache.save(self.keyid, self.vcode, scope,name,opts, response.body)

--- a/lib/eaal/exception.rb
+++ b/lib/eaal/exception.rb
@@ -27,6 +27,11 @@ module EAAL::Exception
 
   # Used when an http error is encountered
   class HTTPError < EAALError
+    attr_reader :status
+
+    def initialize(status)
+      @status = status
+    end
   end
 
   # Used when the Eve API returns a 404


### PR DESCRIPTION
HTTP error code is needed because the EVE API does not returns the 202-205 errors if API key is invalid. Returns the http 403 error.
