### PR TITLE
better handling of HTTPErrors

### DIFF
--- a/lib/eaal/api.rb
+++ b/lib/eaal/api.rb
@@ -60,7 +60,12 @@ class EAAL::API
       when 404
         raise EAAL::Exception::APINotFoundError.new("The requested API (#{scope} / #{name}) could not be found.")
       else
-        raise EAAL::Exception::HTTPError.new(response.status), "An HTTP Error occurred, body: #{response.body}"
+        if response.body
+          doc = Hpricot.XML(response.body)
+          result = EAAL::Result.new(scope.capitalize + name, doc)
+        else
+          raise EAAL::Exception::HTTPError.new(response.status), "An HTTP Error occurred, body: #{response.body}"
+        end
       end
 
       EAAL.cache.save(self.keyid, self.vcode, scope,name,opts, response.body)


### PR DESCRIPTION
not sure if this is the proper way to do it - but its better than just dying completely :)

before, the code would stop unable to catch particular exceptions because it already had an HTTPError. with this now i can do (this is in my key model validation)

```
begin
  result = api.APIKeyInfo()
rescue EAAL::Exception.EveAPIException(220), EAAL::Exception.EveAPIException(222) => e
  pp e.inspect
  self.valid_key = false
  self.save(validate: false)
  return false
end
```

and catch specific exceptions.
